### PR TITLE
apply some checks and improve shutdown

### DIFF
--- a/pkg/proletariat/communication.go
+++ b/pkg/proletariat/communication.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	ErrNotTCP      = errors.New("address is not TCP")
-	ErrInvalidAddr = errors.New("address can not be used")
+	ErrNotTCP        = errors.New("address is not TCP")
+	ErrInvalidAddr   = errors.New("address can not be used")
+	ErrAlreadyClosed = errors.New("communication was already closed")
 )
 
 // Peer address

--- a/pkg/proletariat/flag.go
+++ b/pkg/proletariat/flag.go
@@ -1,0 +1,39 @@
+package proletariat
+
+import "sync/atomic"
+
+const (
+	active   = 0x0
+	inactive = 0x1
+)
+
+// The Flag structure.
+// Only some transitions are available when using this structure,
+// so this will not act as an atomic boolean. The accepted transitions are:
+//
+// IsActive if flag is 0x0, returns `true`;
+// IsInactive if flag is 0x1, returns `true`;
+// Inactivate iff IsActive change value to IsInactive.
+//
+// The start value will be `active`.
+type Flag struct {
+	// Holds the current state of the flag.
+	flag int32
+}
+
+// Returns `true` if the flag still active.
+func (f *Flag) IsActive() bool {
+	return atomic.LoadInt32(&f.flag) == active
+}
+
+// Returns `true` if the flag is inactive.
+func (f *Flag) IsInactive() bool {
+	return atomic.LoadInt32(&f.flag) == inactive
+}
+
+// Will inactivate the flag.
+// Returns `true` if was active and now is inactive and returns `false`
+// if it was already inactivated.
+func (f *Flag) Inactivate() bool {
+	return atomic.CompareAndSwapInt32(&f.flag, active, inactive)
+}


### PR DESCRIPTION
Added some validations, to ensure that nothing is executed after the communication is closed. To avoid being blocked on shutdown, the `closed` channel is now buffered.