### PR TITLE
handle context for network connection

### DIFF
--- a/pkg/proletariat/network_connection.go
+++ b/pkg/proletariat/network_connection.go
@@ -25,6 +25,9 @@ type ConnectionConfiguration struct {
 	// Parent context to bound the connection methods.
 	Ctx context.Context
 
+	// Cancel the current context.
+	Cancel context.CancelFunc
+
 	// The actual connection.
 	Connection net.Conn
 
@@ -95,6 +98,7 @@ func (n *NetworkConnection) digest() ([]byte, error) {
 
 // Implements the Connection interface.
 func (n *NetworkConnection) Close() error {
+	n.configuration.Cancel()
 	n.decoder.Release()
 	n.encoder.Release()
 	return n.connection.Close()


### PR DESCRIPTION
Handling context for network connection in a better way to avoid blocked routines. Removed wrong log call.