### PR TITLE
[imp] add message queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,21 @@ package. The only guarantees are the ones implemented by TCP itself and nothing 
 
 ### Benchmark
 
-A simple benchmark, creates a sever and client and publishes 1024 messages:
+A simple benchmark, creates a sever and client for listening messages and publishes 1024 messages:
 
 ```text
 goos: linux
 goarch: amd64
 pkg: github.com/digital-comrades/proletariat/test
 cpu: AMD Ryzen 5 3500X 6-Core Processor             
-Benchmark_CommunicationMessages             	       1	1003044424 ns/op	  487976 B/op	   13564 allocs/op
-Benchmark_CommunicationMessages-2           	       1	1005693788 ns/op	  399464 B/op	   13504 allocs/op
-Benchmark_CommunicationMessages-3           	       1	1005936827 ns/op	  403128 B/op	   13498 allocs/op
-Benchmark_CommunicationMessages-6           	       1	1006335248 ns/op	  393024 B/op	   13502 allocs/op
-Benchmark_CommunicationParallelMessages     	       1	1005231383 ns/op	  400608 B/op	   13521 allocs/op
-Benchmark_CommunicationParallelMessages-2   	       1	1005472590 ns/op	  401072 B/op	   13504 allocs/op
-Benchmark_CommunicationParallelMessages-3   	       1	1006118222 ns/op	  409912 B/op	   13520 allocs/op
-Benchmark_CommunicationParallelMessages-6   	       1	1005206180 ns/op	  404376 B/op	   13529 allocs/op
+Benchmark_CommunicationMessages             	     325	   3797034 ns/op	  371058 B/op	   13248 allocs/op
+Benchmark_CommunicationMessages-2           	     746	   2569464 ns/op	  284241 B/op	   10190 allocs/op
+Benchmark_CommunicationMessages-3           	    1527	   2282558 ns/op	  353102 B/op	   12626 allocs/op
+Benchmark_CommunicationMessages-6           	    1669	   1212951 ns/op	  333823 B/op	   11945 allocs/op
+Benchmark_CommunicationParallelMessages     	     403	   3714202 ns/op	  363654 B/op	   12990 allocs/op
+Benchmark_CommunicationParallelMessages-2   	     786	   1745899 ns/op	  178969 B/op	    6469 allocs/op
+Benchmark_CommunicationParallelMessages-3   	     952	   1864454 ns/op	  193721 B/op	    6991 allocs/op
+Benchmark_CommunicationParallelMessages-6   	    1334	   2575388 ns/op	  271032 B/op	    9719 allocs/op
 ```
 
 ### Comments

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sheerun/queue v1.0.1 h1:TIAQyN0aRRvrJcNa2beZFfxwuxrfXBc9Mj+UWDNH7Ao=
+github.com/sheerun/queue v1.0.1/go.mod h1:YtjrWT5jymvCLo/lEWDk3sv7A1Kgj0qcl3SZx7Zmcfo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/ugorji/go v1.2.4 h1:cTciPbZ/VSOzCLKclmssnfQ/jyoVyOcJ3aoJyUV1Urc=

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/sheerun/queue v1.0.1 h1:TIAQyN0aRRvrJcNa2beZFfxwuxrfXBc9Mj+UWDNH7Ao=
-github.com/sheerun/queue v1.0.1/go.mod h1:YtjrWT5jymvCLo/lEWDk3sv7A1Kgj0qcl3SZx7Zmcfo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/ugorji/go v1.2.4 h1:cTciPbZ/VSOzCLKclmssnfQ/jyoVyOcJ3aoJyUV1Urc=

--- a/pkg/proletariat/buffer.go
+++ b/pkg/proletariat/buffer.go
@@ -1,0 +1,133 @@
+// Copyright (C) 2020-2021 digital-comrades and others.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proletariat
+
+import (
+	"math/rand"
+	"sync"
+)
+
+// Interface to create simple functions for a queue.
+type Queue interface {
+	// Insert a new element to the queue.
+	Append(interface{})
+
+	// Verify the head of the queue, without removing.
+	Peek() interface{}
+
+	// Remove the fist element, nil if empty.
+	Pop() interface{}
+
+	// Channel to be notified when new elements are added.
+	HasElements() <-chan interface{}
+}
+
+// Buffer will hold received messages in a FIFO queue.
+type buffer struct {
+	// Holds the identifiers for each element present on the
+	// buffer. The elements are stored in the same order they
+	// were added.
+	buf []int64
+
+	// Holds the actual elements. The buf holds the identifier
+	// to locate the element in the map.
+	data map[int64]interface{}
+
+	// ReadWrite mutex to safely execute actions.
+	mutex *sync.RWMutex
+
+	// Channel to notify about elements.
+	hasElements chan interface{}
+}
+
+// Create a new queue.
+func NewQueue() Queue {
+	return &buffer{
+		data:        make(map[int64]interface{}),
+		mutex:       &sync.RWMutex{},
+		hasElements: make(chan interface{}),
+	}
+}
+
+// Generate a new identifier that is no currently being used.
+func (b *buffer) newId() int64 {
+	for {
+		id := rand.Int63()
+		_, ok := b.data[id]
+		if id != 0 && !ok {
+			return id
+		}
+	}
+}
+
+// Sends a notification through the channel if the buffer have elements.
+func (b *buffer) notify() {
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+
+	if len(b.buf) > 0 {
+		data := b.data[b.buf[0]]
+		select {
+		case b.hasElements <- data:
+		default:
+		}
+	}
+}
+
+// Insert a new element to the end of the buffer.
+func (b *buffer) Append(i interface{}) {
+	defer b.notify()
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	id := b.newId()
+	b.data[id] = i
+	b.buf = append(b.buf, id)
+}
+
+// Verify the head of the queue. If the queue does not have
+// elements, nil is returned.
+func (b *buffer) Peek() interface{} {
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+
+	if len(b.buf) == 0 {
+		return nil
+	}
+	return b.data[b.buf[0]]
+}
+
+// Listen for the channel.
+func (b *buffer) HasElements() <-chan interface{} {
+	return b.hasElements
+}
+
+// Remove the head of the queue. If there is not element,
+// nil is returned.
+func (b *buffer) Pop() interface{} {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	if len(b.buf) == 0 {
+		return nil
+	}
+
+	id := b.buf[0]
+	data := b.data[id]
+	delete(b.data, id)
+	// Is this destructuring expensive?
+	b.buf = append(b.buf[:0], b.buf[1:]...)
+	return data
+}

--- a/pkg/proletariat/communication.go
+++ b/pkg/proletariat/communication.go
@@ -15,6 +15,7 @@
 package proletariat
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -74,7 +75,7 @@ type Communication interface {
 // Wraps the received data and errors from the connection.
 type Datagram struct {
 	// Received data from the underlining connection.
-	Data []byte
+	Data *bytes.Buffer
 
 	// Errors received from the connection.
 	Err error

--- a/pkg/proletariat/receiver.go
+++ b/pkg/proletariat/receiver.go
@@ -1,0 +1,157 @@
+// Copyright (C) 2020-2021 digital-comrades and others.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proletariat
+
+import (
+	"context"
+	"io"
+	"sync"
+	"time"
+)
+
+const defaultConsumptionTimeout = time.Millisecond
+
+// Receiver should handle all messages received by the connections.
+//
+// When publishing back a message to be consumed by the client,
+// not necessarily it will be consumed directly, so the receiver will
+// keep track of received message to publish it only once.
+type IReceiver interface {
+	io.Closer
+
+	// Will start polling to deliver messages.
+	Start()
+
+	// Insert a new message to be delivered.
+	AddResponse(Datagram)
+}
+
+// A receiver implementation that will keeps messages stored into a
+// FIFO queue. If the client does not consume the messages this queue
+// will only increase.
+//
+// Since messages can be tried to be delivered indefinitely, we can be stuck
+// with a message, delaying everything.
+// TODO: configurable TTL for in-memory messages.
+type fifoReceiver struct {
+	// FIFO queue holding messages to be delivered.
+	queue Queue
+
+	// Used to bound asynchronous commands.
+	timeout time.Duration
+
+	// Channel to publish all received messages.
+	deliver chan<- Datagram
+
+	// Used to close the sending channel only once.
+	once *sync.Once
+
+	// Receiver context.
+	ctx context.Context
+
+	// Receiver cancel to stop working.
+	cancel context.CancelFunc
+}
+
+func NewReceiver(deliver chan<- Datagram, timeout time.Duration, parent context.Context) IReceiver {
+	ctx, cancel := context.WithCancel(parent)
+	return &fifoReceiver{
+		queue:   NewQueue(),
+		timeout: timeout,
+		once:    &sync.Once{},
+		deliver: deliver,
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+}
+
+// Try to send the given datagram through the channel. If successfully consumed
+// returns true, false otherwise.
+//
+// If the context is already closed, we will return `true`, since is not important
+// to add the element to the buffer anymore.
+func (f *fifoReceiver) tryDeliver(datagram Datagram) bool {
+	defer func() {
+		recover()
+	}()
+
+	if f.timeout <= 0 {
+		select {
+		case <-f.ctx.Done():
+			return true
+		case f.deliver <- datagram:
+			return true
+		default:
+			return false
+		}
+	}
+
+	select {
+	case <-f.ctx.Done():
+		return true
+	case f.deliver <- datagram:
+		return true
+	case <-time.After(f.timeout):
+		return false
+	}
+}
+
+// Will try to deliver the element in the head of the queue.
+// If successfully consumed it will be removed.
+func (f *fifoReceiver) peekAndTryDeliver() {
+	head := f.queue.Peek()
+	if head == nil {
+		return
+	}
+	if f.tryDeliver(head.(Datagram)) {
+		f.queue.Pop()
+	}
+}
+
+// Stop the current fifo receiver.
+func (f *fifoReceiver) Close() error {
+	f.cancel()
+	return nil
+}
+
+// Will executed while the application is running.
+// This method is responsible for delivering datagrams that were
+// not sent directly and are present on the buffer.
+func (f *fifoReceiver) Start() {
+	for {
+		select {
+		case <-f.ctx.Done():
+			return
+		case d := <-f.queue.HasElements():
+			if f.tryDeliver(d.(Datagram)) {
+				f.queue.Pop()
+			}
+		default:
+			f.peekAndTryDeliver()
+		}
+	}
+}
+
+// Handle a new received response.
+// First it will try to directly deliver the datagram, if is not possible
+// the datagram will be stored on a buffer to be delivered later.
+//
+// In this approach, some messages can be delivered out of order.
+// TODO: do we care to fix message order?
+func (f *fifoReceiver) AddResponse(datagram Datagram) {
+	if !f.tryDeliver(datagram) {
+		f.queue.Append(datagram)
+	}
+}

--- a/test/communication_bench_test.go
+++ b/test/communication_bench_test.go
@@ -1,0 +1,142 @@
+// Copyright (C) 2020-2021 digital-comrades and others.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"github.com/digital-comrades/proletariat/pkg/proletariat"
+	"sync"
+	"testing"
+)
+
+func sendMultipleMessagesBench(first, second proletariat.Communication, content []byte, testSize int, b *testing.B) {
+	addr := proletariat.Address(first.Addr().String())
+	for i := 0; i < testSize; i++ {
+		err := second.Send(addr, content)
+		if err != nil {
+			b.Errorf("failed writing. %s", err.Error())
+		}
+	}
+}
+
+func Benchmark_CommunicationMessages(b *testing.B) {
+	testSize := 1024
+	wg := &sync.WaitGroup{}
+	ctx, cancel := context.WithCancel(context.TODO())
+	first, err := proletariat.NewCommunication(proletariat.Configuration{
+		Address: "127.0.0.1:0",
+		Timeout: 0,
+		Ctx:     ctx,
+	})
+	if err != nil {
+		b.Fatalf("failed tcp one: %v", err)
+	}
+
+	second, err := proletariat.NewCommunication(proletariat.Configuration{
+		Address:  "127.0.0.1:0",
+		Timeout:  0,
+		Ctx:      ctx,
+		PoolSize: 10,
+	})
+	if err != nil {
+		b.Fatalf("failed tcp two: %v", err)
+	}
+
+	go first.Start()
+	go second.Start()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for d := range first.Receive() {
+			if d.Err != nil && IsClosedError(d.Err) {
+				return
+			}
+		}
+	}()
+
+	content := []byte("hello world")
+	for i := 0; i < b.N; i++ {
+		sendMultipleMessagesBench(first, second, content, testSize, b)
+	}
+
+	cancel()
+
+	if err := first.Close(); err != nil {
+		b.Errorf("failed closing first. %s", err.Error())
+	}
+
+	if err := second.Close(); err != nil {
+		b.Errorf("failed closing second. %s", err.Error())
+	}
+
+	wg.Wait()
+}
+
+func Benchmark_CommunicationParallelMessages(b *testing.B) {
+	testSize := 1024
+	wg := &sync.WaitGroup{}
+	ctx, cancel := context.WithCancel(context.TODO())
+	first, err := proletariat.NewCommunication(proletariat.Configuration{
+		Address: "127.0.0.1:0",
+		Timeout: 0,
+		Ctx:     ctx,
+	})
+	if err != nil {
+		b.Fatalf("failed tcp one: %v", err)
+	}
+
+	second, err := proletariat.NewCommunication(proletariat.Configuration{
+		Address:  "127.0.0.1:0",
+		Timeout:  0,
+		Ctx:      ctx,
+		PoolSize: 10,
+	})
+	if err != nil {
+		b.Fatalf("failed tcp two: %v", err)
+	}
+
+	go first.Start()
+	go second.Start()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for d := range first.Receive() {
+			if d.Err != nil && IsClosedError(d.Err) {
+				return
+			}
+		}
+	}()
+
+	content := []byte("hello world")
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			sendMultipleMessagesBench(first, second, content, testSize, b)
+		}
+	})
+
+	cancel()
+
+	if err := first.Close(); err != nil {
+		b.Errorf("failed closing first. %s", err.Error())
+	}
+
+	if err := second.Close(); err != nil {
+		b.Errorf("failed closing second. %s", err.Error())
+	}
+
+	wg.Wait()
+}

--- a/test/communication_test.go
+++ b/test/communication_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 )
 
-func sendMultipleMessages(first, second proletariat.Communication, testSize int, b *testing.B) {
+func sendMultipleMessages(first, second proletariat.Communication, testSize int, t *testing.T) {
 	content := []byte("Ola, Mundo!")
 	addr := proletariat.Address(first.Addr().String())
 	wg := &sync.WaitGroup{}
@@ -36,7 +36,10 @@ func sendMultipleMessages(first, second proletariat.Communication, testSize int,
 			select {
 			case <-time.After(time.Second):
 				return
-			case <-first.Receive():
+			case d := <-first.Receive():
+				if d.Err != nil && IsClosedError(d.Err) {
+					return
+				}
 				atomic.AddInt64(&counter, 1)
 			}
 		}
@@ -45,17 +48,17 @@ func sendMultipleMessages(first, second proletariat.Communication, testSize int,
 	for i := 0; i < testSize; i++ {
 		err := second.Send(addr, content)
 		if err != nil {
-			b.Errorf("failed writing. %s", err.Error())
+			t.Errorf("failed writing. %s", err.Error())
 		}
 	}
 
 	wg.Wait()
 	if atomic.LoadInt64(&counter) != int64(testSize) {
-		b.Errorf("expected %d. found %d", testSize, atomic.LoadInt64(&counter))
+		t.Errorf("expected %d. found %d", testSize, atomic.LoadInt64(&counter))
 	}
 }
 
-func Benchmark_CommunicationMessages(b *testing.B) {
+func Test_LoadCommunicationMessages(t *testing.T) {
 	testSize := 1024
 	ctx, cancel := context.WithCancel(context.TODO())
 	first, err := proletariat.NewCommunication(proletariat.Configuration{
@@ -64,7 +67,7 @@ func Benchmark_CommunicationMessages(b *testing.B) {
 		Ctx:     ctx,
 	})
 	if err != nil {
-		b.Fatalf("failed tcp one: %v", err)
+		t.Fatalf("failed tcp one: %v", err)
 	}
 
 	second, err := proletariat.NewCommunication(proletariat.Configuration{
@@ -74,65 +77,20 @@ func Benchmark_CommunicationMessages(b *testing.B) {
 		PoolSize: 10,
 	})
 	if err != nil {
-		b.Fatalf("failed tcp two: %v", err)
+		t.Fatalf("failed tcp two: %v", err)
 	}
 
 	go first.Start()
 	go second.Start()
 
-	for i := 0; i < b.N; i++ {
-		sendMultipleMessages(first, second, testSize, b)
-	}
-
+	sendMultipleMessages(first, second, testSize, t)
 	cancel()
 
 	if err := first.Close(); err != nil {
-		b.Errorf("failed closing first. %s", err.Error())
+		t.Errorf("failed closing first. %s", err.Error())
 	}
 
 	if err := second.Close(); err != nil {
-		b.Errorf("failed closing second. %s", err.Error())
-	}
-}
-
-func Benchmark_CommunicationParallelMessages(b *testing.B) {
-	testSize := 1024
-	ctx, cancel := context.WithCancel(context.TODO())
-	first, err := proletariat.NewCommunication(proletariat.Configuration{
-		Address: "127.0.0.1:0",
-		Timeout: 0,
-		Ctx:     ctx,
-	})
-	if err != nil {
-		b.Fatalf("failed tcp one: %v", err)
-	}
-
-	second, err := proletariat.NewCommunication(proletariat.Configuration{
-		Address:  "127.0.0.1:0",
-		Timeout:  0,
-		Ctx:      ctx,
-		PoolSize: 10,
-	})
-	if err != nil {
-		b.Fatalf("failed tcp two: %v", err)
-	}
-
-	go first.Start()
-	go second.Start()
-
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			sendMultipleMessages(first, second, testSize, b)
-		}
-	})
-
-	cancel()
-
-	if err := first.Close(); err != nil {
-		b.Errorf("failed closing first. %s", err.Error())
-	}
-
-	if err := second.Close(); err != nil {
-		b.Errorf("failed closing second. %s", err.Error())
+		t.Errorf("failed closing second. %s", err.Error())
 	}
 }

--- a/test/receiver_test.go
+++ b/test/receiver_test.go
@@ -1,0 +1,84 @@
+// Copyright (C) 2020-2021 digital-comrades and others.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"bytes"
+	"context"
+	"github.com/digital-comrades/proletariat/pkg/proletariat"
+	"go.uber.org/goleak"
+	"sync"
+	"testing"
+	"time"
+)
+
+func Test_FIFOQueue(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	q := proletariat.NewQueue()
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	for i := 0; i < 1000; i++ {
+		q.Append(i)
+	}
+
+	go func() {
+		defer wg.Done()
+		i := 0
+		e := q.Pop()
+		for ; e != nil; e = q.Pop() {
+			if e != i {
+				t.Errorf("expected %d found %d", i, e)
+			}
+			i++
+		}
+	}()
+
+	wg.Wait()
+}
+
+func Test_ShouldAddAndReadLater(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	testSize := 1024
+	read := make(chan proletariat.Datagram)
+	ctx, cancel := context.WithCancel(context.TODO())
+	r := proletariat.NewReceiver(read, 0, ctx)
+
+	go r.Start()
+
+	for i := 0; i < testSize; i++ {
+		data := []byte{byte(i)}
+		r.AddResponse(proletariat.Datagram{Data: bytes.NewBuffer(data)})
+	}
+
+	for i := 0; i < testSize; i++ {
+		expected := []byte{byte(i)}
+		select {
+		case <-time.After(time.Second):
+			t.Error("did not read messages")
+			goto C
+		case d := <-read:
+			if !bytes.Equal(expected, d.Data.Bytes()) {
+				t.Errorf("expected %#v and found %#v", expected, d.Data.Bytes())
+			}
+		}
+	}
+
+C:
+	cancel()
+	if err := r.Close(); err != nil {
+		t.Errorf("failed closing. %v", err)
+	}
+}

--- a/test/tcp_communication_test.go
+++ b/test/tcp_communication_test.go
@@ -62,8 +62,8 @@ func TestTCPCommunication_CreateAndSend(t *testing.T) {
 		if msg.Err != nil {
 			t.Errorf("should not receive error. %#v", msg.Err)
 		}
-		if string(content) != string(msg.Data) {
-			t.Errorf("failed. should be %s found %s", string(content), string(msg.Data))
+		if string(content) != msg.Data.String() {
+			t.Errorf("failed. should be %s found %s", string(content), msg.Data.String())
 		}
 	}()
 

--- a/test/testing.go
+++ b/test/testing.go
@@ -15,7 +15,9 @@
 package test
 
 import (
+	"github.com/digital-comrades/proletariat/pkg/proletariat"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -38,4 +40,8 @@ func PrintStackTrace(t *testing.T) {
 	buf := make([]byte, 1<<16)
 	runtime.Stack(buf, true)
 	t.Errorf("%s", buf)
+}
+
+func IsClosedError(err error) bool {
+	return strings.Contains(err.Error(), proletariat.ClosedConnection)
 }


### PR DESCRIPTION
Previously, if nobody is listening the produced datagrams, the write
operation will block the `network_connection` of receiving more
messages. To avoid this, a `buffer` was created, that will hold all
received messages into a FIFO queue.

The first action is trying to deliver the message through the channel,
if is not possible it will be added to the message buffer to be
delivered later. This behavior can lead to message being delivered out
of order, but I think is something simple to solve.

Another problem is that messages can be stuck on the buffer forever, and
the buffer will only grow. If we do not care for discarding messages, a
TTL can be added with a configurable parameter.

Also fixed the benchmark, previously we were waiting to close after 1
second without receiving, and this was breaking the `ns/ops` the always
be 1 second. Now we only validate the sending of 1024 messages, since a
single message made the `b.N` to execute too many times, sometimes not
finishing.

Executing the benchmarks without consuming the messages also lead to
benchmarks executing forever. I think is because the use of mutexes to
insert the messages to the buffer.